### PR TITLE
fix: rename service_endpoints to endpoint_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_endpoint_type"></a> [endpoint\_type](#input\_endpoint\_type) | The endpoint type to communicate with the provided secrets manager instance. Possible values are `public` or `private` | `string` | `"public"` | no |
 | <a name="input_imported_cert_certificate"></a> [imported\_cert\_certificate](#input\_imported\_cert\_certificate) | The TLS certificate to import. | `string` | `null` | no |
 | <a name="input_imported_cert_intermediate"></a> [imported\_cert\_intermediate](#input\_imported\_cert\_intermediate) | (optional) The intermediate certificate for the TLS certificate to import. | `string` | `null` | no |
 | <a name="input_imported_cert_private_key"></a> [imported\_cert\_private\_key](#input\_imported\_cert\_private\_key) | (optional) The private key for the TLS certificate to import. | `string` | `null` | no |
@@ -193,7 +194,6 @@ No modules.
 | <a name="input_service_credentials_source_service_crn"></a> [service\_credentials\_source\_service\_crn](#input\_service\_credentials\_source\_service\_crn) | The CRN of the source service instance to create the service credential. | `string` | `null` | no |
 | <a name="input_service_credentials_source_service_role"></a> [service\_credentials\_source\_service\_role](#input\_service\_credentials\_source\_service\_role) | The role to give the service credential in the source service. | `string` | `null` | no |
 | <a name="input_service_credentials_ttl"></a> [service\_credentials\_ttl](#input\_service\_credentials\_ttl) | The time-to-live (TTL) to assign to generated service credentials (in seconds). | `number` | `"7776000"` | no |
-| <a name="input_service_endpoints"></a> [service\_endpoints](#input\_service\_endpoints) | The service endpoint type to communicate with the provided secrets manager instance. Possible values are `public` or `private` | `string` | `"public"` | no |
 
 ### Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,7 @@ resource "ibm_sm_arbitrary_secret" "arbitrary_secret" {
   description     = var.secret_description
   labels          = var.secret_labels
   payload         = var.secret_payload_password
-  endpoint_type   = var.service_endpoints
+  endpoint_type   = var.endpoint_type
 }
 
 resource "ibm_sm_username_password_secret" "username_password_secret" {
@@ -56,7 +56,7 @@ resource "ibm_sm_username_password_secret" "username_password_secret" {
   labels          = var.secret_labels
   username        = var.secret_username
   password        = var.secret_payload_password
-  endpoint_type   = var.service_endpoints
+  endpoint_type   = var.endpoint_type
 
   ## This for_each block is NOT a loop to attach to multiple rotation blocks.
   ## This block is only used to conditionally add rotation block depending on var.sm_iam_secret_auto_rotation
@@ -89,7 +89,7 @@ resource "ibm_sm_imported_certificate" "imported_cert" {
   certificate     = local.imported_cert_certificate
   private_key     = local.imported_cert_private_key
   intermediate    = local.imported_cert_intermediate
-  endpoint_type   = var.service_endpoints
+  endpoint_type   = var.endpoint_type
 }
 
 resource "ibm_sm_service_credentials_secret" "service_credentials_secret" {
@@ -101,7 +101,7 @@ resource "ibm_sm_service_credentials_secret" "service_credentials_secret" {
   description     = var.secret_description
   labels          = var.secret_labels
   ttl             = var.service_credentials_ttl
-  endpoint_type   = var.service_endpoints
+  endpoint_type   = var.endpoint_type
 
   source_service {
     instance {

--- a/variables.tf
+++ b/variables.tf
@@ -112,13 +112,13 @@ variable "service_credentials_source_service_role" {
   default     = null
 }
 
-variable "service_endpoints" {
+variable "endpoint_type" {
   type        = string
-  description = "The service endpoint type to communicate with the provided secrets manager instance. Possible values are `public` or `private`"
+  description = "The endpoint type to communicate with the provided secrets manager instance. Possible values are `public` or `private`"
   default     = "public"
   validation {
-    condition     = contains(["public", "private"], var.service_endpoints)
-    error_message = "The specified service_endpoints is not a valid selection!"
+    condition     = contains(["public", "private"], var.endpoint_type)
+    error_message = "The specified endpoint_type is not a valid selection!"
   }
 }
 


### PR DESCRIPTION
### Description

service_endpoints variable renamed to endpoint_type.

related issue: https://github.com/terraform-ibm-modules/terraform-ibm-secrets-manager-secret/issues/132

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
