### PR TITLE
fix(deps): bump cos and secrets manager

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -37,7 +37,7 @@ module "resource_group" {
 
 module "secrets_manager" {
   source               = "terraform-ibm-modules/secrets-manager/ibm"
-  version              = "1.15.1"
+  version              = "1.18.6"
   resource_group_id    = module.resource_group.resource_group_id
   region               = local.sm_region
   secrets_manager_name = "${var.prefix}-secrets-manager"
@@ -197,15 +197,19 @@ module "secret_manager_imported_cert" {
 
 # create a COS instance to create the service credential for
 module "cloud_object_storage" {
-  source                 = "terraform-ibm-modules/cos/ibm"
-  version                = "8.5.3"
-  resource_group_id      = module.resource_group.resource_group_id
-  region                 = var.region
-  cos_instance_name      = "${var.prefix}-cos"
-  cos_tags               = var.resource_tags
-  bucket_name            = "${var.prefix}-bucket"
-  retention_enabled      = false # disable retention for test environments - enable for stage/prod
-  kms_encryption_enabled = false
+  source                             = "terraform-ibm-modules/cos/ibm"
+  version                            = "8.11.14"
+  resource_group_id                  = module.resource_group.resource_group_id
+  region                             = var.region
+  cos_instance_name                  = "${var.prefix}-cos"
+  cos_tags                           = var.resource_tags
+  bucket_name                        = "${var.prefix}-bucket"
+  activity_tracker_read_data_events  = false
+  activity_tracker_write_data_events = false
+  request_metrics_enabled            = false
+  retention_enabled                  = false # disable retention for test environments - enable for stage/prod
+  kms_encryption_enabled             = false
+  usage_metrics_enabled              = false
 }
 
 #create a service authorization between Secrets Manager and the target service (COS)


### PR DESCRIPTION
### Description

Bump secrets manager and cos per renovate pipeline.

The renovate pipeline fails in #170 due to upgrade example using the COS module. The COS module changed monitoring and activity tracking to enabled by default. Additional properties are required to retain back compatibility in the example for the upgrade test to pass.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

No release required. This is renovate to the examples with additional COS options to retain backward compatibility.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
